### PR TITLE
fix: use `ps -w` to list processes

### DIFF
--- a/luasrc/controller/unblockneteasemusic.lua
+++ b/luasrc/controller/unblockneteasemusic.lua
@@ -24,7 +24,7 @@ end
 
 function act_status()
 	local e = {}
-	e.running = luci.sys.call("ps |grep unblockneteasemusic |grep app.js |grep -v grep >/dev/null") == 0
+	e.running = luci.sys.call("ps -w |grep unblockneteasemusic |grep app.js |grep -v grep >/dev/null") == 0
 	luci.http.prepare_content("application/json")
 	luci.http.write_json(e)
 end

--- a/root/usr/share/unblockneteasemusic/debugging.sh
+++ b/root/usr/share/unblockneteasemusic/debugging.sh
@@ -59,7 +59,7 @@ echo -e "\n"
 echo -e "Running info:"
 procd_running_status="$(/etc/init.d/unblockneteasemusic status)"
 echo -e "PROCD running status: $procd_running_status"
-[ "$procd_running_status" = "running" ] && { ps | grep "unblockneteasemusic" | grep "app\.js" || echo -e "Thread is not found."; }
+[ "$procd_running_status" = "running" ] && { ps -w | grep "unblockneteasemusic" | grep "app\.js" || echo -e "Thread is not found."; }
 echo -e "\n"
 
 [ "$procd_running_status" != "running" ] || {

--- a/root/usr/share/unblockneteasemusic/update.sh
+++ b/root/usr/share/unblockneteasemusic/update.sh
@@ -5,7 +5,7 @@
 NAME="unblockneteasemusic"
 
 check_core_if_already_running(){
-	running_tasks="$(ps |grep "$NAME" |grep "update.sh" |grep "update_core" |grep -v "grep" |awk '{print $1}' |wc -l)"
+	running_tasks="$(ps -w |grep "$NAME" |grep "update.sh" |grep "update_core" |grep -v "grep" |awk '{print $1}' |wc -l)"
 	[ "${running_tasks}" -gt "2" ] && { echo -e "\nA task is already running." >> "/tmp/$NAME.log"; exit 2; }
 }
 


### PR DESCRIPTION
without `-w` it may cause no output in some cases.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>