### PR TITLE
feat(init): add support for 'nftset'

### DIFF
--- a/root/etc/init.d/unblockneteasemusic
+++ b/root/etc/init.d/unblockneteasemusic
@@ -129,18 +129,19 @@ start_service()
 	local lan_addr="$(uci -q get network.lan.ipaddr)"
 	local tmp="/tmp/$NAME"
 	if [ "${hijack_ways}" = "use_ipset" ]; then
-		# TODO: wating for dnsmasq support nftset
+		local ipset="ipset"
+		[ -n "$(dnsmasq --version | grep -m1 'Compile time options:' | cut -d: -f2 | grep ' nftset')" ] && ipset="nftset"
 		mkdir -p "/tmp/dnsmasq.d"
 		rm -f "/tmp/dnsmasq.d/dnsmasq-$NAME.conf"
 		cat <<-EOF > "/tmp/dnsmasq.d/dnsmasq-$NAME.conf"
 			dhcp-option=252,http://${lan_addr}:${http_port}/proxy.pac
-			ipset=/.music.163.com/neteasemusic
-			ipset=/interface.music.163.com/neteasemusic
-			ipset=/interface3.music.163.com/neteasemusic
-			ipset=/apm.music.163.com/neteasemusic
-			ipset=/apm3.music.163.com/neteasemusic
-			ipset=/clientlog.music.163.com/neteasemusic
-			ipset=/clientlog3.music.163.com/neteasemusic
+			${ipset}=/.music.163.com/neteasemusic
+			${ipset}=/interface.music.163.com/neteasemusic
+			${ipset}=/interface3.music.163.com/neteasemusic
+			${ipset}=/apm.music.163.com/neteasemusic
+			${ipset}=/apm3.music.163.com/neteasemusic
+			${ipset}=/clientlog.music.163.com/neteasemusic
+			${ipset}=/clientlog3.music.163.com/neteasemusic
 		EOF
 		/etc/init.d/dnsmasq reload
 


### PR DESCRIPTION
use 'nftset' to replace 'ipset' if dnsmasq support.(>2.87)